### PR TITLE
slice(): use Buffer concat for Node.js

### DIFF
--- a/benchmarks/append.js
+++ b/benchmarks/append.js
@@ -25,7 +25,7 @@ for (let i = 0; i < REPEAT; i++) {
     buf.append(Uint8Array.from([i, j, 1, 2, 3, 4, 5]))
   }
 
-  buf.toUint8Array()
+  buf.slice()
 }
 
 console.info('Uint8ArrayList', Date.now() - start, 'ms') // eslint-disable-line no-console

--- a/benchmarks/slice.js
+++ b/benchmarks/slice.js
@@ -1,0 +1,33 @@
+import BufferList from 'bl/BufferList.js'
+import { Uint8ArrayList } from '../dist/src/index.js'
+
+const REPEAT = 10000
+let start = Date.now()
+
+for (let i = 0; i < REPEAT; i++) {
+  const buf = new BufferList()
+
+  for (let j = 0; j < REPEAT; j++) {
+    const arr = [i, j, 1, 2, 3, 4, 5]
+    buf.append(Uint8Array.from(arr))
+    buf.slice()
+    buf.consume(arr.length)
+  }
+}
+
+console.info('slice BufferList', Date.now() - start, 'ms') // eslint-disable-line no-console
+
+start = Date.now()
+
+for (let i = 0; i < REPEAT; i++) {
+  const buf = new Uint8ArrayList()
+
+  for (let j = 0; j < REPEAT; j++) {
+    const arr = [i, j, 1, 2, 3, 4, 5]
+    buf.append(Uint8Array.from(arr))
+    buf.slice()
+    buf.consume(arr.length)
+  }
+}
+
+console.info('slice Uint8ArrayList', Date.now() - start, 'ms') // eslint-disable-line no-console

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,22 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
   slice (beginInclusive?: number, endExclusive?: number) {
     const { bufs, length } = this._subList(beginInclusive, endExclusive)
 
+    if (bufs.length === 1) {
+      if (bufs[0].length === length) {
+        return bufs[0]
+      }
+      if (typeof Buffer !== 'undefined') {
+        return Buffer.from(bufs[0].buffer).slice(0, length)
+      }
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      // For Node.js environment, use Buffer to improve performance
+      // See https://github.com/achingbrain/uint8arraylist/issues/24
+      return Buffer.concat(bufs.map((buf) => Buffer.from(buf.buffer)), length)
+    }
+
+    // For Browser
     return concat(bufs, length)
   }
 


### PR DESCRIPTION
**Motivation**
Lodestar experienced performance issue in slice() function, see https://github.com/achingbrain/uint8arraylist/issues/24#issue-1316422497

**Description**
- Use `Buffer.concat()` for better performance in Node.js, the new benchmark shows a 1.5x faster than `uint8arrays.concat`, it also should save memory allocation in the long run
- If the slice() returns 1 single `buf`, return early (which should save us 1 memory allocation)
- Note that `Buffer.from(Uint8Array.buffer)` doesn't do any memory allocation