### PR TITLE
Improve slice() if spanning 1 internal buffer

### DIFF
--- a/benchmarks/slice.js
+++ b/benchmarks/slice.js
@@ -2,32 +2,39 @@ import BufferList from 'bl/BufferList.js'
 import { Uint8ArrayList } from '../dist/src/index.js'
 
 const REPEAT = 10000
-let start = Date.now()
 
-for (let i = 0; i < REPEAT; i++) {
-  const buf = new BufferList()
+const testCases = [
+  { name: 'BufferList', factoryFn: () => new BufferList() },
+  { name: 'Uint8ArrayList', factoryFn: () => new Uint8ArrayList() }
+]
 
-  for (let j = 0; j < REPEAT; j++) {
-    buf.append(Uint8Array.from([i, j, 1, 2, 3, 4, 5]))
-    buf.append(Uint8Array.from([i, j, 1, 2, 3, 4, 5]))
-    buf.slice()
-    buf.consume(buf.length)
+for (const { name, factoryFn } of testCases) {
+  const start = Date.now()
+  for (let i = 0; i < REPEAT; i++) {
+    const buf = factoryFn()
+
+    for (let j = 0; j < REPEAT; j++) {
+      buf.append(Buffer.from([i, j, 1, 2, 3, 4, 5]))
+      buf.slice()
+      buf.consume(buf.length)
+    }
   }
+
+  console.info(`${name} - slice() spanning 1 buffer`, Date.now() - start, 'ms') // eslint-disable-line no-console
 }
 
-console.info('slice BufferList', Date.now() - start, 'ms') // eslint-disable-line no-console
+for (const { name, factoryFn } of testCases) {
+  const start = Date.now()
+  for (let i = 0; i < REPEAT; i++) {
+    const buf = factoryFn()
 
-start = Date.now()
-
-for (let i = 0; i < REPEAT; i++) {
-  const buf = new Uint8ArrayList()
-
-  for (let j = 0; j < REPEAT; j++) {
-    buf.append(Uint8Array.from([i, j, 1, 2, 3, 4, 5]))
-    buf.append(Uint8Array.from([i, j, 1, 2, 3, 4, 5]))
-    buf.slice()
-    buf.consume(buf.length)
+    for (let j = 0; j < REPEAT; j++) {
+      buf.append(Buffer.from([i, j, 1, 2, 3, 4, 5]))
+      buf.append(Buffer.from([i, j, 1, 2, 3, 4, 5]))
+      buf.slice()
+      buf.consume(buf.length)
+    }
   }
-}
 
-console.info('slice Uint8ArrayList', Date.now() - start, 'ms') // eslint-disable-line no-console
+  console.info(`${name} - slice() spanning 2 buffers`, Date.now() - start, 'ms') // eslint-disable-line no-console
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,15 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
 
   slice (beginInclusive?: number, endExclusive?: number) {
     const { bufs, length } = this._subList(beginInclusive, endExclusive)
+    // similar to bl.slice, if the requested range spans a single internal buffer
+    // then a subarray of that buffer will be returned which shares the original memory range of that Buffer
+    if (bufs.length === 1) {
+      if (length === bufs[0].length) {
+        return bufs[0]
+      } else {
+        return bufs[0].subarray(0, length)
+      }
+    }
 
     return concat(bufs, length)
   }


### PR DESCRIPTION
**Motivation**

- Get through the bottle neck issue in lodestar when we copy buffer unnecessarily https://github.com/achingbrain/uint8arraylist/issues/24#issue-1316422497

**Description**
- Follow `bl.slice()` spec: `If the requested range spans a single internal buffer then a slice of that buffer will be returned which shares the original memory range of that Buffer. If the range spans multiple buffers then copy operations will likely occur to give you a uniform Buffer.`
- Refactor `slice()` benchmark

Closes #24 