### PR TITLE
feat!: add sublist method and change subarray return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,13 +144,40 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
     }
   }
 
-  slice (beginInclusive?: number, endExclusive?: number) {
+  /**
+   * Extracts a section of an array and returns a new array.
+   *
+   * This is a copy operation as it is with Uint8Arrays and Arrays
+   * - note this is different to the behaviour of Node Buffers.
+   */
+  slice (beginInclusive?: number, endExclusive?: number): Uint8Array {
     const { bufs, length } = this._subList(beginInclusive, endExclusive)
 
     return concat(bufs, length)
   }
 
-  subarray (beginInclusive?: number, endExclusive?: number) {
+  /**
+   * Returns a new Uint8Array from the given start and end element index.
+   *
+   * In the best case where the data extracted comes from a single Uint8Array
+   * internally this is a no-copy operation otherwise it is a copy operation.
+   */
+  subarray (beginInclusive?: number, endExclusive?: number): Uint8Array {
+    const { bufs, length } = this._subList(beginInclusive, endExclusive)
+
+    if (bufs.length === 1) {
+      return bufs[0]
+    }
+
+    return concat(bufs, length)
+  }
+
+  /**
+   * Returns a new Uint8ArrayList from the given start and end element index.
+   *
+   * This is a no-copy operation.
+   */
+  sublist (beginInclusive?: number, endExclusive?: number): Uint8ArrayList {
     const { bufs } = this._subList(beginInclusive, endExclusive)
 
     const list = new Uint8ArrayList()
@@ -159,13 +186,21 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
     return list
   }
 
-  _subList (beginInclusive?: number, endExclusive?: number) {
+  private _subList (beginInclusive?: number, endExclusive?: number) {
     if (beginInclusive == null && endExclusive == null) {
       return { bufs: this.bufs, length: this.length }
     }
 
     beginInclusive = beginInclusive ?? 0
     endExclusive = endExclusive ?? (this.length > 0 ? this.length : 0)
+
+    if (beginInclusive < 0) {
+      beginInclusive = this.length + beginInclusive
+    }
+
+    if (endExclusive < 0) {
+      endExclusive = this.length + endExclusive
+    }
 
     if (beginInclusive < 0 || endExclusive > this.length) {
       throw new RangeError('index out of bounds')

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,14 +194,6 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
     beginInclusive = beginInclusive ?? 0
     endExclusive = endExclusive ?? (this.length > 0 ? this.length : 0)
 
-    if (beginInclusive < 0) {
-      beginInclusive = this.length + beginInclusive
-    }
-
-    if (endExclusive < 0) {
-      endExclusive = this.length + endExclusive
-    }
-
     if (beginInclusive < 0 || endExclusive > this.length) {
       throw new RangeError('index out of bounds')
     }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -229,7 +229,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.slice(0, 4), 'ascii')).to.equal('abcd')
       expect(toString(bl.slice(0, 3), 'ascii')).to.equal('abc')
       expect(toString(bl.slice(1, 4), 'ascii')).to.equal('bcd')
-      expect(toString(bl.slice(-4, -1), 'ascii')).to.equal('abc')
+      expect(() => toString(bl.slice(-4, -1), 'ascii')).to.throw(RangeError)
     })
 
     it('multiple bytes from multiple buffers', () => {
@@ -249,7 +249,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.slice(3, 6), 'ascii')).to.equal('def')
       expect(toString(bl.slice(3, 8), 'ascii')).to.equal('defgh')
       expect(toString(bl.slice(5, 10), 'ascii')).to.equal('fghij')
-      expect(toString(bl.slice(-7, -4), 'ascii')).to.equal('def')
+      expect(() => toString(bl.slice(-7, -4), 'ascii')).to.throw(RangeError)
     })
   })
 
@@ -264,7 +264,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.subarray(0, 4).slice(), 'ascii')).to.equal('abcd')
       expect(toString(bl.subarray(0, 3).slice(), 'ascii')).to.equal('abc')
       expect(toString(bl.subarray(1, 4).slice(), 'ascii')).to.equal('bcd')
-      expect(toString(bl.subarray(-4, -1).slice(), 'ascii')).to.equal('abc')
+      expect(() => toString(bl.subarray(-4, -1).slice(), 'ascii')).to.throw(RangeError)
     })
 
     it('multiple bytes from multiple buffers', () => {
@@ -284,7 +284,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.subarray(3, 6).slice(), 'ascii')).to.equal('def')
       expect(toString(bl.subarray(3, 8).slice(), 'ascii')).to.equal('defgh')
       expect(toString(bl.subarray(5, 10).slice(), 'ascii')).to.equal('fghij')
-      expect(toString(bl.subarray(-7, -4).slice(), 'ascii')).to.equal('def')
+      expect(() => toString(bl.subarray(-7, -4).slice(), 'ascii')).to.throw(RangeError)
     })
   })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -229,7 +229,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.slice(0, 4), 'ascii')).to.equal('abcd')
       expect(toString(bl.slice(0, 3), 'ascii')).to.equal('abc')
       expect(toString(bl.slice(1, 4), 'ascii')).to.equal('bcd')
-      expect(() => toString(bl.slice(-4, -1), 'ascii')).to.throw(RangeError)
+      expect(toString(bl.slice(-4, -1), 'ascii')).to.equal('abc')
     })
 
     it('multiple bytes from multiple buffers', () => {
@@ -249,7 +249,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.slice(3, 6), 'ascii')).to.equal('def')
       expect(toString(bl.slice(3, 8), 'ascii')).to.equal('defgh')
       expect(toString(bl.slice(5, 10), 'ascii')).to.equal('fghij')
-      expect(() => toString(bl.slice(-7, -4), 'ascii')).to.throw(RangeError)
+      expect(toString(bl.slice(-7, -4), 'ascii')).to.equal('def')
     })
   })
 
@@ -264,7 +264,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.subarray(0, 4).slice(), 'ascii')).to.equal('abcd')
       expect(toString(bl.subarray(0, 3).slice(), 'ascii')).to.equal('abc')
       expect(toString(bl.subarray(1, 4).slice(), 'ascii')).to.equal('bcd')
-      expect(() => toString(bl.subarray(-4, -1).slice(), 'ascii')).to.throw(RangeError)
+      expect(toString(bl.subarray(-4, -1).slice(), 'ascii')).to.equal('abc')
     })
 
     it('multiple bytes from multiple buffers', () => {
@@ -284,7 +284,7 @@ describe('Uint8arrayList', () => {
       expect(toString(bl.subarray(3, 6).slice(), 'ascii')).to.equal('def')
       expect(toString(bl.subarray(3, 8).slice(), 'ascii')).to.equal('defgh')
       expect(toString(bl.subarray(5, 10).slice(), 'ascii')).to.equal('fghij')
-      expect(() => toString(bl.subarray(-7, -4).slice(), 'ascii')).to.throw(RangeError)
+      expect(toString(bl.subarray(-7, -4).slice(), 'ascii')).to.equal('def')
     })
   })
 


### PR DESCRIPTION
Refactors the sub* methods and adds comments to clarify their purpose.

* slice is a copy operation, retruns a Uint8Array
* subarray is no-copy if possible, returns a Uint8Array
* sublist is always no-copy, returns a Uint8ArrayList

n.b. slice for node Buffers is no-copy, for Uint8Arrays (and Arrays) it is copy

BREAKING CHANGE: subarray now returns a Uint8Array - use sublist if you need a Uint8ArrayList