### PR TITLE
feat: add fromUint8Arrays factory method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,9 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
     this.bufs = []
     this.length = 0
 
-    this.appendAll(data)
+    if (data.length) {
+      this.appendAll(data)
+    }
   }
 
   * [Symbol.iterator] () {
@@ -477,5 +479,22 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
     }
 
     return true
+  }
+
+  /**
+   * Create a Uint8ArrayList from a pre-existing list of Uint8Arrays.  Use this
+   * method if you know the total size of all the Uint8Arrays ahead of time.
+   */
+  static fromUint8Arrays (bufs: Uint8Array[], length?: number): Uint8ArrayList {
+    const list = new Uint8ArrayList()
+    list.bufs = bufs
+
+    if (length == null) {
+      length = bufs.reduce((acc, curr) => acc + curr.byteLength, 0)
+    }
+
+    list.length = length
+
+    return list
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
     this.bufs = []
     this.length = 0
 
-    if (data.length) {
+    if (data.length > 0) {
       this.appendAll(data)
     }
   }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1149,4 +1149,29 @@ describe('Uint8arrayList', () => {
       expect(listA.equals(listB)).to.be.false('equalled falsy value')
     })
   })
+
+  describe('fromUint8Arrays', () => {
+    it('should create a list from an array of Uint8Arrays', () => {
+      const listA = new Uint8ArrayList(
+        Uint8Array.from([0, 1, 2, 3, 4, 5]),
+        Uint8Array.from([0, 1, 2, 3, 4, 5])
+      )
+      const listB = Uint8ArrayList.fromUint8Arrays([
+        Uint8Array.from([0, 1, 2, 3, 4, 5]),
+        Uint8Array.from([0, 1, 2, 3, 4, 5])
+      ])
+
+      expect(listA.equals(listB)).to.be.true('did not match other list')
+      expect(listB).to.have.property('byteLength', 12, 'did not calculate length property')
+    })
+
+    it('should support passing pre-calculated length of Uint8Arrays', () => {
+      const list = Uint8ArrayList.fromUint8Arrays([
+        Uint8Array.from([0, 1, 2, 3, 4, 5]),
+        Uint8Array.from([0, 1, 2, 3, 4, 5])
+      ], 11) // byte length is actually 12
+
+      expect(list).to.have.property('byteLength', 11, 'did not honour length property')
+    })
+  })
 })


### PR DESCRIPTION
To support the use case where we have a list of `Uint8Array`s and we already know their length, allow creating a `Uint8ArrayList` without looping over every buf to count the length as it can be slow.