### PR TITLE
fix: return copy of internal buffer list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ export class Uint8ArrayList implements Iterable<Uint8Array> {
     }
 
     if (beginInclusive === 0 && endExclusive === this.length) {
-      return { bufs: this.bufs, length: this.length }
+      return { bufs: [...this.bufs], length: this.length }
     }
 
     const bufs: Uint8Array[] = []


### PR DESCRIPTION
Instead of returning the actual list, return a copy of the internal buffer list so we can modify the list without rug-pulling other lists built on top of it.